### PR TITLE
Remove timer and randomize mob size on spawn

### DIFF
--- a/data/bonjour/function/init.mcfunction
+++ b/data/bonjour/function/init.mcfunction
@@ -1,7 +1,6 @@
-scoreboard objectives add mobscale_timer dummy
+# scoreboard for random size
 scoreboard objectives add mobscale_random dummy
-scoreboard players set #mobtimer mobscale_timer 0
 scoreboard players set #rand mobscale_random 0
-scoreboard players set $max mobscale_random 381
+scoreboard players set $max mobscale_random 10
 # Armor stand random
 execute unless entity @e[type=armor_stand,tag=mobscale_random] run summon armor_stand ~ ~-64 ~ {Tags:["mobscale_random"],Invisible:1b,Marker:1b,NoGravity:1b,CustomName:'{"text":"mobrand"}'}

--- a/data/bonjour/function/mobscale_random.mcfunction
+++ b/data/bonjour/function/mobscale_random.mcfunction
@@ -1,6 +1,5 @@
 execute as @e[type=armor_stand,tag=mobscale_random,limit=1] at @s run spreadplayers 0 0 0 100 false @s
 execute as @e[type=armor_stand,tag=mobscale_random,limit=1] store result score #rand mobscale_random run data get entity @s Pos[0] 1
-scoreboard players set $max mobscale_random 10
 scoreboard players operation #rand mobscale_random %= $max mobscale_random
 execute if score #rand mobscale_random matches 0 run function bonjour:setsize_0_2
 execute if score #rand mobscale_random matches 1 run function bonjour:setsize_0_6

--- a/data/bonjour/function/setsize_0_2.mcfunction
+++ b/data/bonjour/function/setsize_0_2.mcfunction
@@ -1,1 +1,2 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 0.2
+attribute @s minecraft:scale base set 0.2
+tag @s add mobscale_scaled

--- a/data/bonjour/function/setsize_0_6.mcfunction
+++ b/data/bonjour/function/setsize_0_6.mcfunction
@@ -1,1 +1,2 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 0.6
+attribute @s minecraft:scale base set 0.6
+tag @s add mobscale_scaled

--- a/data/bonjour/function/setsize_1_0.mcfunction
+++ b/data/bonjour/function/setsize_1_0.mcfunction
@@ -1,1 +1,2 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 1.0
+attribute @s minecraft:scale base set 1.0
+tag @s add mobscale_scaled

--- a/data/bonjour/function/setsize_1_4.mcfunction
+++ b/data/bonjour/function/setsize_1_4.mcfunction
@@ -1,1 +1,2 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 1.4
+attribute @s minecraft:scale base set 1.4
+tag @s add mobscale_scaled

--- a/data/bonjour/function/setsize_1_8.mcfunction
+++ b/data/bonjour/function/setsize_1_8.mcfunction
@@ -1,1 +1,2 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 1.8
+attribute @s minecraft:scale base set 1.8
+tag @s add mobscale_scaled

--- a/data/bonjour/function/setsize_2_2.mcfunction
+++ b/data/bonjour/function/setsize_2_2.mcfunction
@@ -1,1 +1,2 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 2.2
+attribute @s minecraft:scale base set 2.2
+tag @s add mobscale_scaled

--- a/data/bonjour/function/setsize_2_6.mcfunction
+++ b/data/bonjour/function/setsize_2_6.mcfunction
@@ -1,1 +1,2 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 2.6
+attribute @s minecraft:scale base set 2.6
+tag @s add mobscale_scaled

--- a/data/bonjour/function/setsize_3_0.mcfunction
+++ b/data/bonjour/function/setsize_3_0.mcfunction
@@ -1,1 +1,2 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 3.0
+attribute @s minecraft:scale base set 3.0
+tag @s add mobscale_scaled

--- a/data/bonjour/function/setsize_3_4.mcfunction
+++ b/data/bonjour/function/setsize_3_4.mcfunction
@@ -1,1 +1,2 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 3.4
+attribute @s minecraft:scale base set 3.4
+tag @s add mobscale_scaled

--- a/data/bonjour/function/setsize_4_0.mcfunction
+++ b/data/bonjour/function/setsize_4_0.mcfunction
@@ -1,1 +1,2 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 4.2
+attribute @s minecraft:scale base set 4.0
+tag @s add mobscale_scaled

--- a/data/bonjour/function/tick.mcfunction
+++ b/data/bonjour/function/tick.mcfunction
@@ -1,3 +1,1 @@
-scoreboard players add #mobtimer mobscale_timer 1
-execute if score #mobtimer mobscale_timer matches 300 run function bonjour:mobscale_random
-execute if score #mobtimer mobscale_timer matches 301 run scoreboard players set #mobtimer mobscale_timer 0
+execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore,tag=!mobscale_scaled] at @s run function bonjour:mobscale_random


### PR DESCRIPTION
## Summary
- clean up random scaling setup
- newly spawned mobs are sized immediately, no timer
- avoid resetting max size during mob scaling

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685dcabf286c832bafc5db351925a999