### PR TITLE
Apply random size on mob spawn

### DIFF
--- a/data/bonjour/function/init.mcfunction
+++ b/data/bonjour/function/init.mcfunction
@@ -1,7 +1,2 @@
-scoreboard objectives add mobscale_timer dummy
 scoreboard objectives add mobscale_random dummy
-scoreboard players set #mobtimer mobscale_timer 0
-scoreboard players set #rand mobscale_random 0
-scoreboard players set $max mobscale_random 381
-# Armor stand random
-execute unless entity @e[type=armor_stand,tag=mobscale_random] run summon armor_stand ~ ~-64 ~ {Tags:["mobscale_random"],Invisible:1b,Marker:1b,NoGravity:1b,CustomName:'{"text":"mobrand"}'}
+scoreboard objectives add mobscale_scaled dummy

--- a/data/bonjour/function/mobscale_spawn.mcfunction
+++ b/data/bonjour/function/mobscale_spawn.mcfunction
@@ -1,0 +1,12 @@
+scoreboard players random @s mobscale_random 0 9
+scoreboard players set @s mobscale_scaled 1
+execute if score @s mobscale_random matches 0 run function bonjour:setsize_0_2
+execute if score @s mobscale_random matches 1 run function bonjour:setsize_0_6
+execute if score @s mobscale_random matches 2 run function bonjour:setsize_1_0
+execute if score @s mobscale_random matches 3 run function bonjour:setsize_1_4
+execute if score @s mobscale_random matches 4 run function bonjour:setsize_1_8
+execute if score @s mobscale_random matches 5 run function bonjour:setsize_2_2
+execute if score @s mobscale_random matches 6 run function bonjour:setsize_2_6
+execute if score @s mobscale_random matches 7 run function bonjour:setsize_3_0
+execute if score @s mobscale_random matches 8 run function bonjour:setsize_3_4
+execute if score @s mobscale_random matches 9 run function bonjour:setsize_4_0

--- a/data/bonjour/function/setsize_0_2.mcfunction
+++ b/data/bonjour/function/setsize_0_2.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 0.2
+execute unless entity @s[tag=mobscale_ignore] run attribute @s minecraft:scale base set 0.2

--- a/data/bonjour/function/setsize_0_6.mcfunction
+++ b/data/bonjour/function/setsize_0_6.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 0.6
+execute unless entity @s[tag=mobscale_ignore] run attribute @s minecraft:scale base set 0.6

--- a/data/bonjour/function/setsize_1_0.mcfunction
+++ b/data/bonjour/function/setsize_1_0.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 1.0
+execute unless entity @s[tag=mobscale_ignore] run attribute @s minecraft:scale base set 1.0

--- a/data/bonjour/function/setsize_1_4.mcfunction
+++ b/data/bonjour/function/setsize_1_4.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 1.4
+execute unless entity @s[tag=mobscale_ignore] run attribute @s minecraft:scale base set 1.4

--- a/data/bonjour/function/setsize_1_8.mcfunction
+++ b/data/bonjour/function/setsize_1_8.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 1.8
+execute unless entity @s[tag=mobscale_ignore] run attribute @s minecraft:scale base set 1.8

--- a/data/bonjour/function/setsize_2_2.mcfunction
+++ b/data/bonjour/function/setsize_2_2.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 2.2
+execute unless entity @s[tag=mobscale_ignore] run attribute @s minecraft:scale base set 2.2

--- a/data/bonjour/function/setsize_2_6.mcfunction
+++ b/data/bonjour/function/setsize_2_6.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 2.6
+execute unless entity @s[tag=mobscale_ignore] run attribute @s minecraft:scale base set 2.6

--- a/data/bonjour/function/setsize_3_0.mcfunction
+++ b/data/bonjour/function/setsize_3_0.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 3.0
+execute unless entity @s[tag=mobscale_ignore] run attribute @s minecraft:scale base set 3.0

--- a/data/bonjour/function/setsize_3_4.mcfunction
+++ b/data/bonjour/function/setsize_3_4.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 3.4
+execute unless entity @s[tag=mobscale_ignore] run attribute @s minecraft:scale base set 3.4

--- a/data/bonjour/function/setsize_4_0.mcfunction
+++ b/data/bonjour/function/setsize_4_0.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore] run attribute @s minecraft:scale base set 4.2
+execute unless entity @s[tag=mobscale_ignore] run attribute @s minecraft:scale base set 4.2

--- a/data/bonjour/function/tick.mcfunction
+++ b/data/bonjour/function/tick.mcfunction
@@ -1,3 +1,1 @@
-scoreboard players add #mobtimer mobscale_timer 1
-execute if score #mobtimer mobscale_timer matches 300 run function bonjour:mobscale_random
-execute if score #mobtimer mobscale_timer matches 301 run scoreboard players set #mobtimer mobscale_timer 0
+execute as @e[type=!player,type=!armor_stand,type=!marker,tag=!mobscale_ignore,scores={mobscale_scaled=0}] run function bonjour:mobscale_spawn


### PR DESCRIPTION
## Summary
- randomize mob size only when a new mob appears
- record whether a mob has been resized
- keep scaling functions but apply them to the executing entity

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685e96953c90832bae532b2aecc75cee